### PR TITLE
Fix broken hamburger click

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -114,7 +114,7 @@ const NavLinks = ({ scrollToFooter = () => {}, focusFirstLink = false }) => {
         justifyContent: 'space-around',
         alignItems: 'center',
       })}>
-      <Link to='/about' css={linkStyle}>
+      <Link to='/about' innerRef={firstNavRef} css={linkStyle}>
         About
       </Link>
       <Link to='/faq' css={linkStyle}>


### PR DESCRIPTION
Closes https://github.com/eggheadio/illustrated-dev/issues/39

Error was caused by the ref never being set. Works now, and the "about" link is focused when the hamburger menu is opened